### PR TITLE
fix: remove extra slash from the url

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,7 +11,7 @@ export const createApp = () => {
 
   const allowedOrigins = [
     "http://localhost:5173",
-    "https://vwavechallenge.vercel.app/",
+    "https://vwavechallenge.vercel.app",
   ];
 
   const options: cors.CorsOptions = {


### PR DESCRIPTION
# Summary
In this branch, I removed an extra slash from one of the allowed origins URLs.

## Things done:
- Removed an extra slash from the URL.